### PR TITLE
openbmc-mods/preinit-mount: fix restore_op/reformat_ubi_volume case

### DIFF
--- a/meta-openbmc-mods/meta-common/recipes-phosphor/preinit-mounts/preinit-mounts/init
+++ b/meta-openbmc-mods/meta-common/recipes-phosphor/preinit-mounts/preinit-mounts/init
@@ -128,11 +128,12 @@ reformat_ubi_volume() {
     local nv_num="$1"
     local mnt="$2"
     local ubi="/dev/ubi${nv_num}"
+    local mtd="/dev/mtd${nv_num}"
     local vol="${ubi}_0"
     # unmount the volume to reformat it
     umount -f "$mnt"
     ubidetach -m $nv_num
-    ubiformat -y "$ubi"
+    ubiformat -y "$mtd"
     prepare_ubi_volume $nv_num
     # remount the UBIFS on the UBI volume
     mount -t ubifs "$vol" "$mnt"


### PR DESCRIPTION
The ubi_format command should be applied to the MTD device
rather than the ubi device (otherwise trying .restore_op == 3
ends-up not doing anything).

Tested:
 - echo 3 > /tmp/.rwfs/.restore_op
  [ use debug-init on kernel command-line ]
 - reboot
 - checks output of /tmp/init.log, and pristine dflts
