### PR TITLE
icu: Fix download URI

### DIFF
--- a/poky/meta/recipes-support/icu/icu_64.2.bb
+++ b/poky/meta/recipes-support/icu/icu_64.2.bb
@@ -6,13 +6,18 @@ def icu_download_version(d):
     pvsplit = d.getVar('PV').split('.')
     return pvsplit[0] + "_" + pvsplit[1]
 
+def git_download_version(d):
+    pvsplit = d.getVar('PV').split('.')
+    return pvsplit[0] + "-" + pvsplit[1]
+
 ICU_PV = "${@icu_download_version(d)}"
+GIT_PV = "${@git_download_version(d)}"
 
 # http://errors.yoctoproject.org/Errors/Details/20486/
 ARM_INSTRUCTION_SET_armv4 = "arm"
 ARM_INSTRUCTION_SET_armv5 = "arm"
 
-BASE_SRC_URI = "http://download.icu-project.org/files/icu4c/${PV}/icu4c-${ICU_PV}-src.tgz"
+BASE_SRC_URI = "https://github.com/unicode-org/icu/releases/download/release-${GIT_PV}/icu4c-${ICU_PV}-src.tgz"
 SRC_URI = "${BASE_SRC_URI} \
            file://icu-pkgdata-large-cmd.patch \
            file://fix-install-manx.patch \
@@ -26,5 +31,5 @@ SRC_URI_append_class-target = "\
 SRC_URI[md5sum] = "a3d18213beec454e3cdec9a3116d6b05"
 SRC_URI[sha256sum] = "627d5d8478e6d96fc8c90fed4851239079a561a6a8b9e48b0892f24e82d31d6c"
 
-UPSTREAM_CHECK_REGEX = "(?P<pver>\d+(\.\d+)+)/"
-UPSTREAM_CHECK_URI = "http://download.icu-project.org/files/icu4c/"
+UPSTREAM_CHECK_REGEX = "icu4c-(?P<pver>\d+(_\d+)+)/"
+UPSTREAM_CHECK_URI = "https://github.com/unicode-org/icu/releases/download/release-${GIT_PV}/"


### PR DESCRIPTION
The official download site for icu-project is github.
Fix the recipe to download from there as the currently
used download.icu-project.org is not reachable.

Signed-off-by: Alexander Amelkin <a.amelkin@yadro.com>